### PR TITLE
Allow Interactive SVG Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ The file type to be used can be set to either `png` or `svg`. The default is `sv
 {{#drawio:ChartName|type=png}}
 ```
 
+### Use an Object Tag
+MediaWiki normally embeds images inside `<img>` tags and links them to their description page. If you want to use SVG multimedia functions (e.g. links) it has to be embedded as `<object>`. This can be set using the interactive attribute or generally by enabling `$wgDrawioEditorImageInteractive = true` in LocalSettings.php.
+
+```wiki
+{{#drawio:ChartName|interactive}}
+```
+
 
 # Privacy
 As mentioned in the Warnings Section above, **there are some privacy concerns when using this plugin (or draw.io in general)**. Carefully read the information below, especially when you're running a wiki in a private environment.

--- a/resources/ext.drawioeditor.js
+++ b/resources/ext.drawioeditor.js
@@ -1,10 +1,11 @@
 
-function DrawioEditor(id, filename, type, updateHeight, updateWidth, updateMaxWidth) {
+function DrawioEditor(id, filename, type, interactive, updateHeight, updateWidth, updateMaxWidth) {
     var that = this;
     
     this.id = id;
     this.filename = filename;
     this.imgType = type;
+    this.interactive = interactive;
     this.updateHeight = updateHeight;
     this.updateWidth = updateWidth;
     this.updateMaxWidth = updateMaxWidth;
@@ -19,7 +20,11 @@ function DrawioEditor(id, filename, type, updateHeight, updateWidth, updateMaxWi
 
     this.imageBox = $("#drawio-img-box-" + id);
     this.image = $("#drawio-img-" + id);
-    this.imageURL = this.image.attr('src');
+    if (interactive) {
+        this.imageURL = this.image.attr('data');
+    } else {
+        this.imageURL = this.image.attr('src');
+    }
     this.imageHref = $("#drawio-img-href-" + id);
     this.placeholder = $("#drawio-placeholder-" + id);
 
@@ -77,7 +82,11 @@ DrawioEditor.prototype.hideOverlay = function() {
 
 DrawioEditor.prototype.updateImage = function (imageinfo) {
     this.imageURL = imageinfo.url + '?ts=' + imageinfo.timestamp;
-    this.image.attr("src", this.imageURL);
+    if (this.interactive) {
+        this.image.attr("data", this.imageURL);
+    } else {
+        this.image.attr("src", this.imageURL);
+    }
     this.imageHref.attr("href", imageinfo.descriptionurl);
     if (this.updateHeight)
         this.image.css('height', imageinfo.height);


### PR DESCRIPTION
Enable the plugin to embed SVG images using the object HTML tag by
specifying the 'interactive' option. Like this interactive SVG functions
can be used.