### PR TITLE
handle response error on status success

### DIFF
--- a/resources/ext.drawioeditor.js
+++ b/resources/ext.drawioeditor.js
@@ -1,7 +1,7 @@
 
 function DrawioEditor(id, filename, type, interactive, updateHeight, updateWidth, updateMaxWidth) {
     var that = this;
-    
+
     this.id = id;
     this.filename = filename;
     this.imgType = type;
@@ -44,14 +44,14 @@ function DrawioEditor(id, filename, type, interactive, updateHeight, updateWidth
 
     this.iframeOverlay = $("#drawio-iframe-overlay-" + id);
     this.iframeOverlay.hide();
- 
+
     this.iframe = $('<iframe>', {
         src: 'https://www.draw.io/?embed=1&proto=json&spin=1&analytics=0&db=0&gapi=0&od=0&picker=0',
 	id: 'drawio-iframe-' + id,
 	class: 'DrawioEditorIframe'
     })
     this.iframe.appendTo(this.iframeBox);
-    
+
     this.iframeWindow = this.iframe.prop('contentWindow');
 
     this.show();
@@ -183,7 +183,7 @@ DrawioEditor.prototype.loadImage = function() {
     // draw.io xml data. see DrawioEditor.saveCallback()
     this.downloadFromWiki();
 }
- 
+
 DrawioEditor.prototype.uploadToWiki = function(blob) {
     var that = this;
 
@@ -221,10 +221,16 @@ DrawioEditor.prototype.uploadToWiki = function(blob) {
 	    }
         },
         error: function(xhr, status, error) {
-	    that.showDialog('Save failed', 
-	        'Upload to wiki failed!' +
-		'<br>Error: ' + error +
-		'<br>Check javascript console for details.');
+			var response = JSON.parse( xhr.responseText );
+			if ( response.upload.result === "Failure" ) {
+				that.showDialog( 'Save failed',
+						'Upload to wiki failed!' +
+						'<br>Error: ' + error +
+						'<br>Check javascript console for details.' );
+			} else {
+				that.updateImage( response.upload.imageinfo );
+				that.hideSpinner();
+			}
         },
     });
 }
@@ -234,7 +240,7 @@ DrawioEditor.prototype.save = function(datauri) {
     // this.saveCallback()
 
     parts = /^data:([^;,=]+\/[^;,=]+)?((?:;[^;,=]+=[^;,=]+)+)?(?:;(base64))?,(.+)$/.exec(datauri);
-    
+
     // currently this save/upload to wiki code assumes that drawio passes data
     // URIs with base64 encoded data. this is currently the case but may not be
     // true forever. the check below errors out if the URI data is not base64
@@ -251,7 +257,7 @@ DrawioEditor.prototype.save = function(datauri) {
     for (i = 0; i < datastr.length; i++) {
         data[i] = datastr.charCodeAt(i);
     }
-    
+
     this.uploadToWiki(new Blob([data], {type: this.imgMimeType}));
 }
 
@@ -306,10 +312,10 @@ function drawioHandleMessage(e) {
     // we only act on event coming from draw.io iframes
     if (e.origin != 'https://www.draw.io')
         return;
-    
+
     if (!editor)
         return;
-       
+
     evdata = JSON.parse(e.data);
 
     switch(evdata['event']) {


### PR DESCRIPTION
After having return status 500 on mediawiki 1.27 this handler ignore the error while the image is successfully created.