### PR TITLE
Fixed bug with svg thumbnail

### DIFF
--- a/DrawioEditor.php
+++ b/DrawioEditor.php
@@ -40,7 +40,7 @@ class DrawioEditor {
         global $wgDrawioEditorImageInteractive;
         
         /* disable caching before any output is generated */
-        $parser->disableCache();
+        $parser->getOutput()->updateCacheExpiry(0);
 
 	/* parse named arguments */
 	$opts = array();

--- a/DrawioEditor.php
+++ b/DrawioEditor.php
@@ -88,7 +88,7 @@ class DrawioEditor {
         $img_name = $name.".drawio.".$opt_type;
         $img = wfFindFile($img_name);
         if ($img) {
-            $img_url = $img->getViewUrl();
+            $img_url = $img->getUrl();
             $img_url_ts = $img_url.'?ts='.$img->nextHistoryLine()->img_timestamp;
             $img_desc_url = $img->getDescriptionUrl();
 	    $img_height = $img->getHeight().'px';


### PR DESCRIPTION
When editing svg, drawio tries to open png thumbnail. This fix shows svg in webpage and allows drawio to edit it.