### PR TITLE
Change MIME media type to image/svg+xml for interactive mode

### DIFF
--- a/DrawioEditor.php
+++ b/DrawioEditor.php
@@ -149,7 +149,7 @@ class DrawioEditor {
 
 	if ($opt_interactive)
         {
-            $img_fmt = '<object id="drawio-img-%s" data="%s" type="text/svg+xml" style="%s"></object>';
+            $img_fmt = '<object id="drawio-img-%s" data="%s" type="image/svg+xml" style="%s"></object>';
             $img_html = sprintf($img_fmt, $id, $img_url_ts, $img_style);
         } else {
             $img_fmt = '<img id="drawio-img-%s" src="%s" title="%s" alt="%s" style="%s"></img>';


### PR DESCRIPTION
# Problem:
text/svg+xml isn't a standard media type at all so I've changed it to image/svg+xml which is defined in the w3 https://www.w3.org/TR/SVG/mimereg.html

## Steps to reproduce
Create one in interactive mode:
`{{#drawio:Test|interactive}}`

Let it display in the browser (FF, Safari doesn't show anything) - Chrome works

# Fix
After applying the fix the charts get displayed in FF, Safari and Chrome


