### PR TITLE
Update DrawioEditor.php

### DIFF
--- a/DrawioEditor.php
+++ b/DrawioEditor.php
@@ -103,7 +103,7 @@ class DrawioEditor {
 
         $css_img_height = $opt_height === 'chart' ? $img_height : $opt_height;
         $css_img_width = $opt_width === 'chart' ? $img_width : $opt_width;
-        $css_img_max_width = $opt_max_width === 'chart' ? $img_width : $opt_max_width;
+        $css_img_max_width = $opt_max_width === 'chart' ? 'fit-content' : $opt_max_width;
 
         /* check for conditions that should or will prevent an edit of the chart */
         $readonly = (!$wgEnableUploads


### PR DESCRIPTION
Work around fixes #22 by letting browsers size this image, not using the zero'd out value of width once the diagram fails to fetch.

If you want to resize down the embedded image I imagine users would specify the width=xxx option in the template. You could always set `max-width: fit-content` and remove all the opt_max_width handling entirely.